### PR TITLE
Solving issue #2, adjust lwp post commands

### DIFF
--- a/check_netscaler_gateway.pl
+++ b/check_netscaler_gateway.pl
@@ -127,7 +127,7 @@ sub netscaler_gateway_client
 {
 	my $plugin = shift;
 
-	my $lwp = LWP::UserAgent->new(keep_alive => 1);
+	my $lwp = LWP::UserAgent->new(keep_alive => 1, env_proxy=>1);
         $lwp->timeout($plugin->opts->timeout);
         $lwp->ssl_opts(verify_hostname => 0, SSL_verify_mode => 0);
 

--- a/check_netscaler_gateway.pl
+++ b/check_netscaler_gateway.pl
@@ -127,7 +127,7 @@ sub netscaler_gateway_client
 {
 	my $plugin = shift;
 
-	my $lwp = LWP::UserAgent->new(keep_alive => 1, env_proxy=>1);
+	my $lwp = LWP::UserAgent->new(keep_alive => 1, env_proxy => 1);
         $lwp->timeout($plugin->opts->timeout);
         $lwp->ssl_opts(verify_hostname => 0, SSL_verify_mode => 0);
 


### PR DESCRIPTION
This will solve issue #2 .
The lwp post commands were adjusted and shortened. 

With these adjustments the plugin now works on our Netscaler Gateway, too.

```
$ /usr/lib/nagios/plugins/check_netscaler_gateway.pl -H login.example.com -u myuser -p mypass -S MyStore  -v
** POST https://login.example.com/cgi/login ==> 302 Object Moved
** POST https://login.example.com/cgi/setclient?wica ==> 200 OK
** POST https://login.example.com/Citrix/MyStoreWeb/Home/Configuration ==> 200 OK (1s)
** POST https://login.example.com/Citrix/MyStoreWeb/Authentication/GetAuthMethods ==> 200 OK
** POST https://login.example.com/Citrix/MyStoreWeb/GatewayAuth/Login ==> 200 OK
** POST https://login.example.com/Citrix/MyStoreWeb/Resources/List ==> 200 OK
** GET https://login.example.com/cgi/logout ==> 200 OK
NetScaler Gateway OK - Desktop-MCP; Desktop-Users;
```

@slauger Please test it if it works for your environment, too. If it doesn't work it probably means that our environment is an isolated case. I will keep the modifications just for me and you can delete this PR.

If your tests are successful, you may want to increase the plugin version :-) 